### PR TITLE
Puppet RVM fixed an error that was keeping us from using it directly in our tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,6 @@
 fixtures:
   repositories:
     "rvm": "https://github.com/maestrodev/puppet-rvm"
-    "rvm": 
-      repo: "https://github.com/rwilcox/puppet-rvm"
-      branch: "add_exec_provider"
     "stdlib": "https://github.com/puppetlabs/puppetlabs-stdlib"
   symlinks:
     "nginx_passenger": "#{source_dir}"


### PR DESCRIPTION
The issue that kept us from using the puppet RVM maestrodev/puppet-rvm#83. But now that's fixed now, and we should track puppet-rvm master