### PR TITLE
ensure bundler, fix permissions for deploy user, allow rails environment to be specified and allow a list of additional system gems

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,12 @@ class nginx_passenger (
         ruby_version => $ruby_version;
     }
 
+    rvm_gem {
+      "${ruby_version}/puppet":
+        require => Rvm_system_ruby["${ruby_version}"],
+        ruby_version => $ruby_version;
+    }
+
     exec { 'create container':
       command => "/bin/mkdir ${www} && /bin/chown www-data:www-data ${www} && /bin/chmod g+rws ${www}",
       unless  => "/usr/bin/test -d ${www}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class nginx_passenger (
     rvm_system_ruby {
       $ruby_version:
         ensure      => 'present',
-        default_use => true;
+        default_use => false;
     }
 
     rvm_gem {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,7 @@ class nginx_passenger (
       }
     }
     else {
-      $options = "${base_options} --auto-download"  
+      $options = "${base_options} --auto-download"
     }
 
     $passenger_deps = [ 'libcurl4-openssl-dev' ]
@@ -63,6 +63,12 @@ class nginx_passenger (
         ensure => $passenger_version,
   		require => Rvm_system_ruby["${ruby_version}"],
   		ruby_version => $ruby_version;
+    }
+
+    rvm_gem {
+      "${ruby_version}/bundler":
+        require => Rvm_system_ruby["${ruby_version}"],
+        ruby_version => $ruby_version;
     }
 
     exec { 'create container':
@@ -99,7 +105,7 @@ class nginx_passenger (
 
     file { $nx_run_dir:
       ensure => directory,
-    } 
+    }
 
     exec { 'create sites-conf':
       path    => ['/usr/bin','/bin'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class nginx_passenger (
     rvm_system_ruby {
       $ruby_version:
         ensure      => 'present',
-        default_use => false;
+        default_use => true;
     }
 
     rvm_gem {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,12 +71,6 @@ class nginx_passenger (
         ruby_version => $ruby_version;
     }
 
-    rvm_gem {
-      "${ruby_version}/puppet":
-        require => Rvm_system_ruby["${ruby_version}"],
-        ruby_version => $ruby_version;
-    }
-
     exec { 'create container':
       command => "/bin/mkdir ${www} && /bin/chown www-data:www-data ${www} && /bin/chmod g+rws ${www}",
       unless  => "/usr/bin/test -d ${www}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,10 @@
 #      Nginx's install directory.
 #   $www
 #      Base directory for
+#   $app_environment
+#     The environment which passenger should start under
+#   $system_gems
+#     Any additional system gems that should be installed alongside the ruby version e.g ['foreman']
 # Actions:
 #
 # Requires:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,9 @@ class nginx_passenger (
   $www    = '/var/www',
   $nginx_source_dir = '',
   $nginx_extra_configure_flags = '',
-  $app_environment = 'production') inherits nginx_passenger::params {
+  $app_environment = 'production',
+  $system_gems = []
+) inherits nginx_passenger::params {
 
     $base_options = "--auto --prefix=${installdir}"
 
@@ -67,6 +69,11 @@ class nginx_passenger (
 
     rvm_gem {
       "${ruby_version}/bundler":
+        require => Rvm_system_ruby["${ruby_version}"],
+        ruby_version => $ruby_version;
+    }
+
+    rvm_gem { $system_gems:
         require => Rvm_system_ruby["${ruby_version}"],
         ruby_version => $ruby_version;
     }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -7,12 +7,14 @@
 #       The title of the resource  is used as the host.
 #   $port
 #       Virtual host port
-#   $root
+#   $root_arg
 #       Virtual host path
 #   $create_root
 #       True or false, allows to create the path for the virtual host
 #   $rails
 #       True or false, sets if the application is rails based or not.
+#   $environment
+#       The rails environment required for the application to startup under, defaults to production
 # Actions:
 #       Creates a virtual host
 #
@@ -37,7 +39,8 @@ define nginx_passenger::vhost(
   $ssl_certificate = '',
   $ssl_certificate_key = '',
   $ssl_port = '443',
-  $ssl_default_server = false
+  $ssl_default_server = false,
+  $environment = 'production',
 ){
   include nginx_passenger
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -52,7 +52,7 @@ define nginx_passenger::vhost(
       ensure  => directory,
       owner   => 'www-data',
       group   => 'www-data',
-      mode    => '0755',
+      mode    => '0775',
     }
   }
 

--- a/templates/vhost.rails.erb
+++ b/templates/vhost.rails.erb
@@ -10,6 +10,7 @@ server {
 
       passenger_enabled on;
       passenger_base_uri /;
+      passenger_app_env <%= @environment %>;
 
       access_log <%= scope['nginx_passenger::logdir'] %>/<%= @host %>_access.log;
       error_log  <%= scope['nginx_passenger::logdir'] %>/<%= @host %>_error.log;


### PR DESCRIPTION
* Ensures bundler is available after ruby is installed (super helpful if performing a cap deploy immediately after provision)
* Fixes permissions to that any user in the www-data group can deploy when the root folder is created
(previously this was broken)
* Allows a runtime environment to be specified for passenger (eg to deploy a stage environment, etc)
* Allows a list of system gems to be specified also